### PR TITLE
remove automatic `pygpgme` install to avoid install of incorrect versions

### DIFF
--- a/providers/repo.rb
+++ b/providers/repo.rb
@@ -81,10 +81,6 @@ def install_rpm
 
   Chef::Log.debug("#{new_resource.name} rpm base url = #{base_url}")
 
-  package 'pygpgme' do
-    ignore_failure true
-  end
-
   log 'pygpgme_warning' do
     message 'The pygpgme package could not be installed. This means GPG verification is not possible for any RPM installed on your system. ' \
             'To fix this, add a repository with pygpgme. Usualy, the EPEL repository for your system will have this. ' \

--- a/providers/repo.rb
+++ b/providers/repo.rb
@@ -83,7 +83,7 @@ def install_rpm
 
   log 'pygpgme_warning' do
     message 'The pygpgme package is not installed. This means GPG verification is not possible for any RPM installed on your system. ' \
-            'To fix this, add a repository with pygpgme. Usualy, the EPEL repository for your system will have this. ' \
+            'To fix this, add a repository with pygpgme. Usually, the EPEL repository for your system will have this. ' \
             'More information: https://fedoraproject.org/wiki/EPEL#How_can_I_use_these_extra_packages.3F and https://github.com/opscode-cookbooks/yum-epel'
 
     level :warn

--- a/providers/repo.rb
+++ b/providers/repo.rb
@@ -82,7 +82,7 @@ def install_rpm
   Chef::Log.debug("#{new_resource.name} rpm base url = #{base_url}")
 
   log 'pygpgme_warning' do
-    message 'The pygpgme package could not be installed. This means GPG verification is not possible for any RPM installed on your system. ' \
+    message 'The pygpgme package is not installed. This means GPG verification is not possible for any RPM installed on your system. ' \
             'To fix this, add a repository with pygpgme. Usualy, the EPEL repository for your system will have this. ' \
             'More information: https://fedoraproject.org/wiki/EPEL#How_can_I_use_these_extra_packages.3F and https://github.com/opscode-cookbooks/yum-epel'
 


### PR DESCRIPTION
#50 was causing quite some headache and tricky to debug. What ended up causing this was that the `package 'pygpgme'` resource installed the wrong version (Python 2.6) (by means of `grep`) whereas the correct library (Python 2.7) was already installed.

Since there is already a code path that warns and handles the non-existence of `pygpgme` I'd vote for eliminating this "smartness" and making things simpler overall.

Thanks & cheerio, Harry.